### PR TITLE
feat(lang): added thai spelling

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,3 +31,9 @@ test('is FALSE with number', () => {
 test('is Chanon equal to Hussein', () => {
   expect(isChanon('Hussein')).toBe(false)
 })
+
+describe('thai chanon spelling' , () => {
+  it('Chanon is equal to its thai spelling ชานน', () => {
+    expect(isChanon('ชานน')).toBe(true)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,5 @@
  */
 export default function isChanon(str: string): boolean {
   if (typeof str !== 'string') return false
-  return str.trim().toLowerCase() === 'chanon'
+  return str.trim().toLowerCase() === 'chanon' || str.trim().toLowerCase() === 'ชานน'
 }


### PR DESCRIPTION
We need to add more coverage for our Thai users. This PR here is IT !!! It adds an extra check to check if Chanon is in fact "tch-a-none" spelled in Thai.

This feature was in demand from all our Bangkok users.

Ref: https://en.wikipedia.org/wiki/Chanon_Santinatornkul